### PR TITLE
Revert "Add the s3_website uploading tool to jekyll docker"

### DIFF
--- a/jekyll/Dockerfile
+++ b/jekyll/Dockerfile
@@ -4,13 +4,10 @@ ADD Gemfile /
 
 # We need build-base because some of the Ruby gems have native extensions. They're deleted \
 # afterwards to slim the image down.
-RUN apk add --update build-base ruby-dev python openjdk7-jre-base && \
+RUN apk add --update build-base ruby-dev python && \
   bundle install --no-cache --clean && \
   apk del build-base ruby-dev && \
   rm /usr/local/bundle/cache/*
-
-# make s3_website download its jar
-RUN bundle exec s3_website install
 
 # Some scripts that use this container need /bin/bash.
 RUN apk add bash

--- a/jekyll/Gemfile
+++ b/jekyll/Gemfile
@@ -6,4 +6,4 @@ gem 'jekyll-asciidoc', '>= 2.0.1'
 gem 'pygments.rb'
 gem 'therubyracer'
 gem 'octopress-debugger'
-gem 's3_website'
+


### PR DESCRIPTION
This reverts commit d8e4c5086d01a5ed88cfbe225dce09fed933f713. It
turns out the s3_website tool is really heavy, and we don't actually
need to use it.