### PR TITLE
Fix for doctools backward compatibility with extant scripts

### DIFF
--- a/doctools/Dockerfile
+++ b/doctools/Dockerfile
@@ -45,7 +45,8 @@ COPY ats-doc-builder/pdf-themes /themes/
 COPY ats-doc-builder/docx-themes /themes/
 COPY ats-doc-builder/bin/* /bin/
 
-VOLUME /workdir
-WORKDIR /workdir
+VOLUME /site
+WORKDIR /site
 ENTRYPOINT ["doctools.py"]
 LABEL io.whalebrew.config.volumes '["~/.pdf-themes:/themes/user"]'
+LABEL io.whalebrew.config.working_dir '/site'

--- a/doctools/README.md
+++ b/doctools/README.md
@@ -15,25 +15,25 @@ This image makes use of the themes and techniques in [ats-doc-builder](https://g
 
 ## Generate an ATS-styled PDF document from an Asciidoc source
 
-    docker run --rm -it -v $(pwd):/workdir advancedtelematic/doctools -f pdf [file]
+    docker run --rm -it -v $(pwd):/site advancedtelematic/doctools -f pdf [file]
 
 ### Use a custom PDF theme
 
 Mount your theme as a file inside `/themes` in the docker container, and use the `-s` option to select the theme:
 
-    docker run --rm -it -v $(pwd):/workdir -v $(pwd)/mytheme.yml:/themes/mytheme.yml advancedtelematic/doctools -f pdf -s mytheme [file]
+    docker run --rm -it -v $(pwd):/site -v $(pwd)/mytheme.yml:/themes/mytheme.yml advancedtelematic/doctools -f pdf -s mytheme [file]
 
 You'll probably want to use one of the existing themes in the [ats-doc-builder](https://github.com/advancedtelematic/ats-doc-builder/tree/master/pdf-themes) repo as a starting point. See the [asciidoctor-pdf documentation](https://github.com/asciidoctor/asciidoctor-pdf/blob/master/docs/theming-guide.adoc) for how to make/modify your theme.
 
 ## Make an MS Word file
 
-    docker run --rm -it -v $(pwd):/workdir advancedtelematic/doctools -f docx [file]
+    docker run --rm -it -v $(pwd):/site advancedtelematic/doctools -f docx [file]
 
 ## Access the tools manually
 
 Override the entrypoint:
 
-    docker run --rm -it -v $(pwd):/workdir --entrypoint [toolname] advancedtelematic/doctools [arguments]
+    docker run --rm -it -v $(pwd):/site --entrypoint [toolname] advancedtelematic/doctools [arguments]
 
 If what you really need/want is to be able to play around a bit without having to start a docker container with each command, you can also override the entrypoint to `/bin/sh` and go from there.
 


### PR DESCRIPTION
Oops. There were scripts out there mounting into the old '/site' directory. Better to leave it where it was, and just add a label telling whalebrew where to look.