### PR TITLE
add java to bitbakery

### DIFF
--- a/bitbakery/Dockerfile
+++ b/bitbakery/Dockerfile
@@ -12,7 +12,7 @@ ENV BITBAKE_FLAGS=""
 # install dependencies
 
 RUN apt-get update -q && \
-    apt-get install -qy build-essential bzip2 chrpath cpio diffstat gawk gcc-multilib git-core libsdl1.2-dev locales python3 qemu socat sudo texinfo unzip wget xterm inetutils-ping && \
+    apt-get install -qy build-essential bzip2 chrpath cpio default-jre diffstat gawk gcc-multilib git-core libsdl1.2-dev locales python3 qemu socat sudo texinfo unzip wget xterm inetutils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/bitbakery/run.sh
+++ b/bitbakery/run.sh
@@ -16,8 +16,9 @@ cp /opt/site.conf conf/
 
 # build image
 bitbake $BITBAKE_FLAGS $IMAGE
+result=$?
 cp $BUILD_DIR/tmp/deploy/images/$TARGET/$IMAGE-$TARGET.otaimg $OUT_DIR
 cp $BUILD_DIR/tmp/deploy/images/$TARGET/u-boot.* $OUT_DIR
 cp -r $BUILD_DIR/tmp/deploy/images/$TARGET/ostree_repo $OUT_DIR
-
+exit $result
 EOF


### PR DESCRIPTION
Adding java as a dependency since it is required if you want to use `garage-sign` with bitbake.